### PR TITLE
Minor bugfix/cleanup in BoxSelection and NavigationDemo examples

### DIFF
--- a/src/Examples (dotnetcore)/11 - BoxSelection/App.fs
+++ b/src/Examples (dotnetcore)/11 - BoxSelection/App.fs
@@ -84,6 +84,8 @@ let mkISg (model : MBoxSelectionDemoModel) (box : MVisibleBox) =
                 }                
             |> Sg.requirePicking
             |> Sg.noEvents
+            |> Sg.fillMode model.rendering.fillMode
+            |> Sg.cullMode model.rendering.cullMode
             |> Sg.withEvents [
                 Sg.onClick (fun _ -> Select box.id)
                 Sg.onEnter (fun _ -> Enter box.id)

--- a/src/Examples (dotnetcore)/12 - NavigationDemo/App.fs
+++ b/src/Examples (dotnetcore)/12 - NavigationDemo/App.fs
@@ -108,8 +108,6 @@ let view (model : MNavigationModeDemoModel) =
                         }
                     |> Sg.noEvents
                     |> Sg.trafo trafo
-                    |> Sg.fillMode model.rendering.fillMode
-                    |> Sg.cullMode model.rendering.cullMode    
 
         [b; s]  |> Sg.ofList 
                 |> Sg.fillMode model.rendering.fillMode


### PR DESCRIPTION
In the _BoxSelection_ example, the rendering settings (cull- & fill mode) now correctly change. Additionally the cull- & fill `IMOD` in the _NavigationDemo_ example is now only applied once for the sphere.