### PR TITLE
removed unneeded option around workingPolygon

### DIFF
--- a/src/Examples (dotnetcore)/07 - Simple2DDrawing/Model.fs
+++ b/src/Examples (dotnetcore)/07 - Simple2DDrawing/Model.fs
@@ -39,7 +39,7 @@ type Model =
     {
         finishedPolygons : plist<Polygon> // we use plist here, since plist is automatically mapped to alists in the adaptive version (See https://rawgit.com/vrvis/aardvark.media/base31/docs/DomainTypeGeneration.html)
 
-        workingPolygon : Option<Polygon> // maybe we have an (unfinished) polygon we are working on
+        workingPolygon : Polygon // the (unfinished) polygon we are working on
         cursor         : Option<V2d>     // the cursor
 
         [<TreatAsValue>]        // since we don't want to have automatically maintained incremental versions of the past, we treat this field as value (the adaptive version becoms IMod<Option<Model>> instead of MOption<MModel>)


### PR DESCRIPTION
In the `07 - Simple2DDrawing` example for .NET Core, the field `Model.workingPolygon` was of type `Option<Polygon>`.
https://github.com/aardvark-platform/aardvark.media/blob/52e130bbc8fc53cb025220e9650461b33de11776/src/Examples%20(dotnetcore)/07%20-%20Simple2DDrawing/Model.fs#L38-L49

However, this field was never set to `None`.  This PR removes `Option<>` and simplifies the corresponding code appropriately.