### PR TITLE
added assembly binding redirect for Aardvark.Cef.WinForms.Process 

### DIFF
--- a/src/Aardvark.Cef.WinForms.Process/Aardvark.Cef.WinForms.Process.fsproj
+++ b/src/Aardvark.Cef.WinForms.Process/Aardvark.Cef.WinForms.Process.fsproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net471;netcoreapp3.1</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>True</DisableImplicitFSharpCoreReference>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseWindowsForms>true</UseWindowsForms>
     <WarnOn>3389;3390;3395</WarnOn>
   </PropertyGroup>
@@ -15,6 +16,8 @@
     <OutputPath>..\..\bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="paket.references" />
+    <None Include="App.config" />
     <Compile Include="Utilities.fs" />
     <Compile Include="IPC.fs" />
     <Compile Include="AardvarkIO.fs" />

--- a/src/Aardvark.Cef.WinForms.Process/App.config
+++ b/src/Aardvark.Cef.WinForms.Process/App.config
@@ -3,4 +3,12 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-99.0.0.0" newVersion="5.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
@hyazinthh This should do the trick. 
Caveat: This is not agnostic to fsharp.core upgrades - since, i failed to properly instruct paket/dotnet to write the correct version into the file :(
