### PR TITLE
fixed script/stylesheet loading order

### DIFF
--- a/src/Aardvark.UI/MutableApp.fs
+++ b/src/Aardvark.UI/MutableApp.fs
@@ -257,7 +257,8 @@ module MutableApp =
                                                                 printfn "%A" e
                                                 )
 
-                                                send (Text.Encoding.UTF8.GetBytes("x" + code))
+                                                let tag = if state.references.Count > 0 then "r" else "x"
+                                                send (Text.Encoding.UTF8.GetBytes(tag + code))
     
                                                 
                                             let mutable o = oldChannels

--- a/src/Aardvark.UI/resources/aardvark.js
+++ b/src/Aardvark.UI/resources/aardvark.js
@@ -925,9 +925,7 @@ if (!aardvark.addReferences) {
             });
         }
 
-        refs.forEach(ref => {
-            aardvark.promise = aardvark.promise.then(() => loadScript(ref));
-        });
+        aardvark.promise = aardvark.promise.then(() => Promise.all(refs.map(loadScript)));
 
         aardvark.promise = aardvark.promise.then(() => userCode());
     };


### PR DESCRIPTION
Fixed script/stylesheet loading not delaying further promises created in eventSocket.onmessage. Originally, onmessage called addReferences within a promise that only then again chained a promise that loaded the scripts -> other onmessages that arrived before the addReferences promise was executed chained their promises before

This solution checks if the code that should be executed is one that also loads stylesheets/scripts (starts with "aardvark.addReferences". It then directly calls the addReferences method without a promise.

The addReferences method itself is also rewritten to a more explicit promise chain. I think the original one was somehow broken, but there might have been other issues in my code when I tested it and started the cleanup. You might want to test this.

Please review!